### PR TITLE
PCI(E) support with basic USB support

### DIFF
--- a/kernel/src/main.zig
+++ b/kernel/src/main.zig
@@ -21,6 +21,7 @@ const PhysAlloc = @import("modules/phys_alloc.zig");
 const ACPI = @import("modules/acpi/acpi.zig");
 const PCI = @import("modules/pci/pci.zig");
 const Display = @import("modules/display/display.zig");
+const USB = @import("modules/usb/usb.zig");
 
 const Modules = [_]Module.ModuleSpec{
     Procedures.Module,
@@ -29,6 +30,7 @@ const Modules = [_]Module.ModuleSpec{
     Interrupts.InterruptsModule,
     PCI.Module,
     Display.Module,
+    USB.Module,
 };
 
 // The following will be our kernel's entry point.

--- a/kernel/src/modules/pci/pci.zig
+++ b/kernel/src/modules/pci/pci.zig
@@ -1,6 +1,7 @@
 pub const ModuleSpec = @import("../module.zig").ModuleSpec;
 pub const ACPI = @import("../acpi/acpi.zig");
 pub const Procedures = @import("../procedures.zig");
+pub const PhysAlloc = @import("../phys_alloc.zig");
 
 pub const Module = ModuleSpec{
     .name = "PCI(e) support",
@@ -8,14 +9,61 @@ pub const Module = ModuleSpec{
     .deinit = null,
 };
 
-pub var MCFG_table: *MCFGTable = undefined;
+pub var MCFG_table: *align(4) MCFGTable = undefined;
 
 pub fn init() void {
     if (ACPI.MCFG_table_ptr) |ptr| MCFG_table = @ptrCast(ptr);
-    Procedures.write_fmt("Found MCFG table: {}\n", .{MCFG_table}) catch {};
+    Procedures.write_fmt("Found MCFG table: {}, with {} entries\n", .{ MCFG_table, MCFG_table.getEntriesAmount() }) catch {};
+
+    for (0..MCFG_table.getEntriesAmount()) |i| {
+        const e = MCFG_table.getEntry(i);
+        Procedures.write_fmt("Entry: {}\n", .{e}) catch {};
+    }
 }
 
 pub const MCFGTable = extern struct {
-    header: ACPI.SDTHeader,
-    _: u8,
+    header: ACPI.SDTHeader align(1),
+    _: u64,
+
+    pub fn getEntriesAmount(self: *align(4) const @This()) usize {
+        return (self.header.length - @sizeOf(MCFGTable)) / 16;
+    }
+
+    pub fn getEntry(self: *align(4) @This(), i: usize) *align(1) ConfigurationEntry {
+        @compileLog(@sizeOf(MCFGTable));
+        return @ptrFromInt(@intFromPtr(self) + 44 + @sizeOf(ConfigurationEntry) * i);
+    }
+};
+
+pub const ConfigurationEntry = packed struct {
+    base_address: u64,
+    segment_group_number: u16,
+    start_pci_bus: u8,
+    end_pci_bus: u8,
+    _: u32,
+};
+
+pub const ExtendedConfigSpace = packed struct {
+    vendor_id: u16,
+    device_id: u16,
+    command: u16,
+    status: u16,
+    revision_id: u8,
+    class_code: u24,
+    cache_line: u8,
+    lat_timer: u8,
+    header_type: u8,
+    bist: u8,
+    bar: u192,
+    cardbus_cis: u32,
+    subsystem_vendor_id: u16,
+    subsystem_id: u16,
+    expansion_rom_addr: u32,
+    cap_pointer: u8,
+    _: u24,
+    __: u32,
+    int_line: u8,
+    int_pin: u8,
+    min_gnt: u8,
+    max_lat: u8,
 };

--- a/kernel/src/modules/pci/pci.zig
+++ b/kernel/src/modules/pci/pci.zig
@@ -33,11 +33,6 @@ pub fn init() void {
             }
         }
     }
-
-    for (functions.items) |function_| {
-        const function = function_.function_ptr;
-        Procedures.write_fmt("[PCIE Function] Class code: {x}, Vendor ID: {x}, Device ID: {x}\n", .{ function.class_code, function.vendor_id, function.device_id }) catch {};
-    }
 }
 
 pub fn getFunctions() []FunctionWrapper {

--- a/kernel/src/modules/pci/pci.zig
+++ b/kernel/src/modules/pci/pci.zig
@@ -22,15 +22,14 @@ pub fn init() void {
 }
 
 pub const MCFGTable = extern struct {
-    header: ACPI.SDTHeader align(1),
-    _: u64,
+    header: ACPI.SDTHeader,
+    _: u64 align(1),
 
     pub fn getEntriesAmount(self: *align(4) const @This()) usize {
         return (self.header.length - @sizeOf(MCFGTable)) / 16;
     }
 
     pub fn getEntry(self: *align(4) @This(), i: usize) *align(1) ConfigurationEntry {
-        @compileLog(@sizeOf(MCFGTable));
         return @ptrFromInt(@intFromPtr(self) + 44 + @sizeOf(ConfigurationEntry) * i);
     }
 };

--- a/kernel/src/modules/pci/pci.zig
+++ b/kernel/src/modules/pci/pci.zig
@@ -12,7 +12,7 @@ pub const Module = ModuleSpec{
 };
 
 pub var MCFG_table: *align(4) MCFGTable = undefined;
-pub var functions: std.ArrayList(FunctionWrapper) = undefined;
+var functions: std.ArrayList(FunctionWrapper) = undefined;
 
 pub fn init() void {
     if (ACPI.MCFG_table_ptr) |ptr| MCFG_table = @ptrCast(ptr);
@@ -38,6 +38,10 @@ pub fn init() void {
         const function = function_.function_ptr;
         Procedures.write_fmt("[PCIE Function] Class code: {x}, Vendor ID: {x}, Device ID: {x}\n", .{ function.class_code, function.vendor_id, function.device_id }) catch {};
     }
+}
+
+pub fn getFunctions() []FunctionWrapper {
+    return functions.items;
 }
 
 inline fn handlePCIEFunction(base_address: u64, controller_id: usize, bus_id: usize, device_id: usize, function_id: usize) void {

--- a/kernel/src/modules/usb/usb.zig
+++ b/kernel/src/modules/usb/usb.zig
@@ -1,7 +1,30 @@
 const ModuleSpec = @import("../module.zig").ModuleSpec;
+const Procedures = @import("../procedures.zig");
+const PCI = @import("../pci/pci.zig");
 
 pub const Module = ModuleSpec{
     .name = "USB Support",
-    .init = null,
+    .init = init,
     .deinit = null,
+};
+
+pub fn init() void {
+    const functions = PCI.getFunctions();
+    for (functions) |function_wrapper| {
+        const function = function_wrapper.function_ptr;
+        if (function.class_code & 0xFFFF00 != 0x0C0300) continue;
+
+        const usb_type: USBType = @enumFromInt(function.class_code & 0xFF);
+        Procedures.write_fmt("USB Type: {}\n", .{usb_type}) catch {};
+    }
+}
+
+const USBType = enum(u32) {
+    UHCI = 0,
+    OHCI = 0x10,
+    EHCI = 0x20,
+    XHCI = 0x30,
+    USB4 = 0x40,
+    Unspecified = 0x80,
+    USBDevice = 0xFE,
 };

--- a/kernel/src/modules/usb/usb.zig
+++ b/kernel/src/modules/usb/usb.zig
@@ -1,0 +1,7 @@
+const ModuleSpec = @import("../module.zig").ModuleSpec;
+
+const Module = ModuleSpec{
+    .name = "USB Support",
+    .init = null,
+    .deinit = null,
+};

--- a/kernel/src/modules/usb/usb.zig
+++ b/kernel/src/modules/usb/usb.zig
@@ -1,6 +1,6 @@
 const ModuleSpec = @import("../module.zig").ModuleSpec;
 
-const Module = ModuleSpec{
+pub const Module = ModuleSpec{
     .name = "USB Support",
     .init = null,
     .deinit = null,


### PR DESCRIPTION
This PR covers the implementation of PCIE detection with the help of the MCFG table, along with the ability to keep track of discovered PCIE functions.
A small part of the USB detection that relies on the newly PCIE functionality has been included as well.